### PR TITLE
Arm64 Dockerfile

### DIFF
--- a/build/bazel/zetasql.patch
+++ b/build/bazel/zetasql.patch
@@ -9,3 +9,24 @@
 @@ -19,1 +19,1 @@
 -package(default_visibility = ["//zetasql/base:zetasql_implementation"])
 +package(default_visibility = ["//visibility:public"])
+
+--- bazel/zetasql_deps_step_2.bzl
++++ bazel/zetasql_deps_step_2.bzl
+@@ -460,13 +460,12 @@ exports_files(["data"])
+             http_archive(
+                 name = "m4",
+                 build_file_content = all_content,
+-                strip_prefix = "m4-1.4.18",
+-                sha256 = "ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab",
++                strip_prefix = "m4-1.4.19",
++                sha256 = "3be4a26d825ffdfda52a56fc43246456989a3630093cced3fbddf4771ee58a70",
+                 urls = [
+-                    "https://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.gz",
+-                    "https://mirrors.kernel.org/gnu/m4/m4-1.4.18.tar.gz",
++                    "https://ftp.gnu.org/gnu/m4/m4-1.4.19.tar.gz",
++                    "https://mirrors.kernel.org/gnu/m4/m4-1.4.19.tar.gz",
+                 ],
+-                patches = ["@com_google_zetasql//bazel:m4.patch"],
+             )
+ 
+         http_archive(

--- a/build/bazel/zetasql_dep.bzl
+++ b/build/bazel/zetasql_dep.bzl
@@ -21,10 +21,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def zetasql_dep():
     http_archive(
         name = "com_google_zetasql",
-        url = "https://github.com/google/zetasql/archive/2021.09.1.tar.gz",
-        strip_prefix = "zetasql-2021.09.1",
+        url = "https://github.com/google/zetasql/archive/2022.02.1.tar.gz",
+        strip_prefix = "zetasql-2022.02.1",
         # Patches applied:
         # - Give visibility to ZetaSQL's base library to reuse some utilities
         patches = ["//build/bazel:zetasql.patch"],
-        sha256 = "30e1565cf654fca0dcb630cece67e5466fa572c457ecd5e3b2a7bc5530b94fda",
+        sha256 = "8617dfc6ea01bb09a550bb61415a3619fc19f10698c7e42c34e1caff578bdfae",
     )

--- a/build/docker/Dockerfile.arm64
+++ b/build/docker/Dockerfile.arm64
@@ -1,0 +1,104 @@
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+################################################################################
+#                                     BUILD                                    #
+################################################################################
+
+# We use the bazel base image which comes with all bazel dependencies.
+FROM arm64v8/ubuntu:impish as build
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN \
+apt-get update && \
+apt-get -y install \
+    python \
+    python3 \
+    python-pkg-resources \
+    python3-pkg-resources \
+    software-properties-common \
+    unzip
+
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test
+
+RUN apt-get -qq update                                                      && \
+    apt-get -qq install -y curl                                             && \
+    apt-get -qq install -y openjdk-8-jdk                                    && \
+    apt-get -qq install -y patch                                            && \
+    apt-get -qq install -y gcc-9 g++-9 libc6-dev make tzdata                && \
+    apt-get -qq install -y ca-certificates libgnutls30                      && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90           \
+                        --slave   /usr/bin/g++ g++ /usr/bin/g++-9           && \
+    update-alternatives --set gcc /usr/bin/gcc-9
+
+# Install Golang
+RUN curl -L -o go1.17.7.linux-arm64.tar.gz https://go.dev/dl/go1.17.7.linux-arm64.tar.gz \
+    && tar -C /usr/local -xzf go1.17.7.linux-arm64.tar.gz
+
+WORKDIR /src
+
+# Install Bazel
+RUN curl -L -o bazel https://releases.bazel.build/3.7.2/release/bazel-3.7.2-linux-arm64 && chmod +x bazel
+
+# Copy over the emulator code base into the container. We explicitly copy only
+# the required files to maximize chances that the layer will be cached. There
+# does not seem to be a nicer way to do this than multiple COPY commands as
+# COPY copies the contents of the source, not the directory itself.
+COPY BUILD.bazel WORKSPACE .bazelrc ./
+COPY common      common/
+COPY gateway     gateway/
+COPY frontend    frontend/
+COPY backend     backend/
+COPY binaries    binaries/
+COPY tests       tests/
+COPY build/bazel build/bazel/
+
+RUN ./bazel build -c opt ...
+
+# Generate licenses file.
+RUN for file in $(find -L src/bazel-src/external                               \
+                       -name "LICENSE" -o -name "COPYING")                   ; \
+    do                                                                         \
+      echo "----"                                                            ; \
+      echo $file                                                             ; \
+      echo "----"                                                            ; \
+      cat $file                                                              ; \
+    done > licenses.txt                                                     && \
+    gzip licenses.txt
+
+###############################################################################
+#                                   RELEASE                                    #
+################################################################################
+
+# Now build the release image from the build image.
+FROM arm64v8/ubuntu:impish
+
+## Copy binaries.
+COPY --from=build /src/bazel-bin/binaries/emulator_main .
+COPY --from=build /src/bazel-bin/binaries/gateway_main_/gateway_main .
+
+RUN apt-get update && apt-get -qq install -y tzdata ca-certificates
+
+## Copy licenses
+COPY --from=build /src/licenses.txt.gz .
+
+## Expose the default ports 9010 (gRPC) and 9020 (REST)
+EXPOSE 9010 9020
+
+## Run the gateway process, bind to 0.0.0.0 as under MacOS, listening on
+## localhost will make the server invisible outside the container.
+CMD ["./gateway_main", "--hostname", "0.0.0.0"]


### PR DESCRIPTION
m4 v1.4.18 has a bug that prevents it from compiling on arm64 architectures (for more information you can view https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/issues/29 and https://lists.gnu.org/archive/html/bug-m4/2021-03/msg00000.html).

This bug has been fixed in m4 v 1.4.19 but it has not been adapted into the upstream zetasql yet. The applied patch upgrades zetasqls m4 dependency to v1.4.19. This change also provide an arm64 docker container that can be used to build a working version of cloud-spanner-emulator.

This change also upgrades zetasql to the latest version to pull in some updates to the build tooling. While the previous version compiled, it had an older version of the build toolchain which caused the build to not be optimized. This resulted in a working binary but one that was ~30% slower than running the emlated amd64 docker container. Upgrading to the latest zetasql improved performance of the arm64 binary by ~155% based on local testing.

This is related to https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/issues/64 and https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/issues/29

