### PR TITLE
fix: macos schema parser build

### DIFF
--- a/backend/schema/parser/ddl_keywords.cc
+++ b/backend/schema/parser/ddl_keywords.cc
@@ -32,6 +32,10 @@ std::string ToToken(absl::string_view word) {
     token = "DEFAULTT";
   } else if (token == "NULL") {
     token = "NULLL";
+  } else if (token == "FALSE") {
+    token = "FALSEE";
+  } else if (token == "TRUE") {
+    token = "TRUEE";
   } else if (token == "TOKEN") {
     token = "TOKENT";
   }

--- a/backend/schema/parser/ddl_parser.jjt
+++ b/backend/schema/parser/ddl_parser.jjt
@@ -325,8 +325,8 @@ void option_key_val() :
   identifier() #key
   "="
   (   <NULLL> #nulll
-    | <TRUE> #bool_true_val
-    | <FALSE> #bool_false_val
+    | <TRUEE> #bool_true_val
+    | <FALSEE> #bool_false_val
     | <INTEGER_LITERAL> #integer_val
     | string_value() #str_val
   )


### PR DESCRIPTION
Building the Bazel target `//binaries:gateway_main` fails on macOS with the following message:

```
ERROR: /Users/andre.bazaglia/Projects/cloud-spanner-emulator/backend/schema/parser/BUILD:26:11: Compiling backend/schema/parser/ddl_parser.cc failed: (Aborted): wrapped_clang_pp failed: error executing command external/local_config_cc/wrapped_clang_pp '-D_FORTIFY_SOURCE=1' -fstack-protector -fcolor-diagnostics -Wall -Wthread-safety -Wself-assign -fno-omit-frame-pointer -O0 -DDEBUG '-std=c++11' ... (remaining 98 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
In file included from backend/schema/parser/ddl_parser.cc:37:
In file included from ./backend/schema/parser/ddl_includes.h:20:
In file included from bazel-out/darwin_arm64-fastbuild/bin/backend/schema/parser/DDLParser.h:7:
In file included from bazel-out/darwin_arm64-fastbuild/bin/backend/schema/parser/DDLParserTokenManager.h:8:
bazel-out/darwin_arm64-fastbuild/bin/backend/schema/parser/DDLParserConstants.h:81:12: error: expected unqualified-id
const  int FALSE = 32;
           ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/mach/boolean.h:85:17: note: expanded from macro 'FALSE'
#define FALSE   0
                ^
In file included from backend/schema/parser/ddl_parser.cc:37:
In file included from ./backend/schema/parser/ddl_includes.h:20:
In file included from bazel-out/darwin_arm64-fastbuild/bin/backend/schema/parser/DDLParser.h:7:
In file included from bazel-out/darwin_arm64-fastbuild/bin/backend/schema/parser/DDLParserTokenManager.h:8:
bazel-out/darwin_arm64-fastbuild/bin/backend/schema/parser/DDLParserConstants.h:191:12: error: expected unqualified-id
const  int TRUE = 87;
           ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/mach/boolean.h:81:17: note: expanded from macro 'TRUE'
#define TRUE    1
                ^
2 errors generated.
Error in child process '/usr/bin/xcrun'. 1
Target //binaries:gateway_main failed to build
```

My understanding is that C/C++ isn't hermetic on Bazel by default and the consts TRUE/FALSE can't be redefined on macOS. So I call them TRUEE and FALSEE instead (similarly to NULL currently being called NULLL, probably to prevent the same issue).

The build succeeds on my M1 Pro MacBook with the changes in that PR.