### PR TITLE
Update Limitations sestion to document lack of support for Foreign Ke…

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ Notable limitations:
   hints. However, index names generated in the emulator cannot be used in the
   emulator or in production.
 
+- `DELETE CASCADE` referential action is not supported. A DDL statement specifying this action will succeed, however, the action will be set as the default `NO ACTION` action.
+
 - Generated primary keys are not supported.
 
 - The [Cloud Spanner PostgreSQL interface](


### PR DESCRIPTION
Update Limitations sestion to document lack of support for Foreign Key DELETE CASCADE feature.

Tracking bug: https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/issues/130