### PR TITLE
Support empty Array of Struct / Do not support null-valued Array of Struct

### DIFF
--- a/backend/query/query_validator.cc
+++ b/backend/query/query_validator.cc
@@ -505,8 +505,8 @@ absl::Status QueryValidator::VisitResolvedLiteral(
     const zetasql::ResolvedLiteral* node) {
   if (node->type()->IsArray() &&
       node->type()->AsArray()->element_type()->IsStruct() &&
-      node->value().is_empty_array()) {
-    return error::UnsupportedArrayConstructorSyntaxForEmptyStructArray();
+      node->value().is_null()) {
+    return error::UnsupportedArrayConstructorSyntaxForNullValuedStructArray();
   }
 
   return DefaultVisit(node);

--- a/common/errors.cc
+++ b/common/errors.cc
@@ -2884,11 +2884,11 @@ absl::Status UnsupportedReturnStructAsColumn() {
       "value. Rewrite the query to flatten the struct fields in the result.");
 }
 
-absl::Status UnsupportedArrayConstructorSyntaxForEmptyStructArray() {
+absl::Status UnsupportedArrayConstructorSyntaxForNullValuedStructArray() {
   return absl::Status(
       absl::StatusCode::kUnimplemented,
       "Unsupported query shape: Spanner does not support array constructor "
-      "syntax for an empty array where array elements are Structs.");
+      "syntax for a null-valued array of struct.");
 }
 
 absl::Status UnsupportedFeatureSafe(absl::string_view feature_type,

--- a/common/errors.h
+++ b/common/errors.h
@@ -695,7 +695,7 @@ absl::Status ReadOnlyTransactionDoesNotSupportReadWriteOnlyFunctions(
 absl::Status CannotInsertDuplicateKeyInsertOrUpdateDml(absl::string_view key);
 // Unsupported query shape errors.
 absl::Status UnsupportedReturnStructAsColumn();
-absl::Status UnsupportedArrayConstructorSyntaxForEmptyStructArray();
+absl::Status UnsupportedArrayConstructorSyntaxForNullValuedStructArray();
 absl::Status UnsupportedFeatureSafe(absl::string_view feature_type,
                                     absl::string_view info_message);
 absl::Status UnsupportedFunction(absl::string_view function_name);


### PR DESCRIPTION
## Issues
- https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/issues/165

## Overview
As mentioned in the above issue, emulator behaves an opposite to the real world Spanner.

### Before

| SQL | emulator  | Spanner(production) |
| ---- | --------- | ---------------------|
| `IF(false, ARRAY<STRUCT<INT64>>[], null)` |  ✅  | ❌  |
| `IF(false, ARRAY<STRUCT<INT64>>[], [])`    |  ❌  |  ✅ | 

### After

| SQL | emulator  | Spanner(production) |
| ---- | --------- | ---------------------|
| `IF(false, ARRAY<STRUCT<INT64>>[], null)` |  ❌   | ❌  |
| `IF(false, ARRAY<STRUCT<INT64>>[], [])`    |  ✅  |  ✅ | 