### PR TITLE
Fix ON CONFLICT subqueries referencing excluded rows

### DIFF
--- a/backend/query/insert_on_conflict_dml_execution.cc
+++ b/backend/query/insert_on_conflict_dml_execution.cc
@@ -65,6 +65,7 @@ using googlesql::ResolvedColumnRef;
 using googlesql::ResolvedDMLValue;
 using googlesql::ResolvedInsertStmt;
 using googlesql::ResolvedOnConflictClauseEnums;
+using googlesql::ResolvedSubqueryExpr;
 }  // namespace
 
 absl::Status InsertOnConflictDoUpdateRewriter::VisitResolvedColumnRef(
@@ -88,13 +89,65 @@ absl::Status InsertOnConflictDoUpdateRewriter::VisitResolvedColumnRef(
   std::pair<const googlesql::Type*, int> column_info =
       column_ids_referenced_from_insert_row_.at(node->column().column_id());
   auto array_element_column_ref = googlesql::MakeResolvedColumnRef(
-      struct_column_holder_->type(), *struct_column_holder_, false);
+      struct_column_holder_->type(), *struct_column_holder_,
+      node->is_correlated());
   // Build RESOLVED_GET_STRUCT_FIELD to extract the column value from the
   // source STRUCT column.
   auto get_struct_field = googlesql::MakeResolvedGetStructField(
       column_info.first, std::move(array_element_column_ref),
       column_info.second);
   PushNodeToStack(std::move(get_struct_field));
+  return absl::OkStatus();
+}
+
+absl::Status InsertOnConflictDoUpdateRewriter::VisitResolvedSubqueryExpr(
+    const ResolvedSubqueryExpr* node) {
+  std::vector<std::unique_ptr<ResolvedColumnRef>> parameter_list;
+  parameter_list.reserve(node->parameter_list_size());
+  bool added_struct_column_holder = false;
+  for (const auto& parameter : node->parameter_list()) {
+    if (column_ids_referenced_from_insert_row_.contains(
+            parameter->column().column_id())) {
+      if (!added_struct_column_holder) {
+        parameter_list.push_back(googlesql::MakeResolvedColumnRef(
+            struct_column_holder_->type(), *struct_column_holder_, false));
+        added_struct_column_holder = true;
+      }
+      continue;
+    }
+    GOOGLESQL_ASSIGN_OR_RETURN(std::unique_ptr<ResolvedColumnRef> parameter_copy,
+                       ProcessNode(parameter.get()));
+    parameter_list.push_back(std::move(parameter_copy));
+  }
+
+  GOOGLESQL_ASSIGN_OR_RETURN(std::unique_ptr<googlesql::ResolvedExpr> in_expr,
+                     ProcessNode(node->in_expr()));
+  GOOGLESQL_ASSIGN_OR_RETURN(std::unique_ptr<googlesql::ResolvedScan> subquery,
+                     ProcessNode(node->subquery()));
+
+  auto copy = googlesql::MakeResolvedSubqueryExpr(
+      node->type(), node->subquery_type(), std::move(parameter_list),
+      std::move(in_expr), std::move(subquery));
+  copy->set_type_annotation_map(node->type_annotation_map());
+  copy->set_in_collation(node->in_collation());
+
+  GOOGLESQL_ASSIGN_OR_RETURN(
+      std::vector<std::unique_ptr<googlesql::ResolvedOption>> hint_list,
+      ProcessNodeList(node->hint_list()));
+  copy->set_hint_list({std::make_move_iterator(hint_list.begin()),
+                       std::make_move_iterator(hint_list.end())});
+
+  const auto parse_location = node->GetParseLocationRangeOrNULL();
+  if (parse_location != nullptr) {
+    copy->SetParseLocationRange(*parse_location);
+  }
+  const auto operator_keyword_parse_location =
+      node->GetOperatorKeywordLocationRangeOrNULL();
+  if (operator_keyword_parse_location != nullptr) {
+    copy->SetOperatorKeywordLocationRange(*operator_keyword_parse_location);
+  }
+
+  PushNodeToStack(std::move(copy));
   return absl::OkStatus();
 }
 

--- a/backend/query/insert_on_conflict_dml_execution.cc
+++ b/backend/query/insert_on_conflict_dml_execution.cc
@@ -109,6 +109,8 @@ absl::Status InsertOnConflictDoUpdateRewriter::VisitResolvedSubqueryExpr(
     if (column_ids_referenced_from_insert_row_.contains(
             parameter->column().column_id())) {
       if (!added_struct_column_holder) {
+        // Replace the column references from insert row with the insert row
+        // value struct.
         parameter_list.push_back(googlesql::MakeResolvedColumnRef(
             struct_column_holder_->type(), *struct_column_holder_, false));
         added_struct_column_holder = true;

--- a/backend/query/insert_on_conflict_dml_execution.h
+++ b/backend/query/insert_on_conflict_dml_execution.h
@@ -61,6 +61,8 @@ class InsertOnConflictDoUpdateRewriter
 
   absl::Status VisitResolvedColumnRef(
       const googlesql::ResolvedColumnRef* node) override;
+  absl::Status VisitResolvedSubqueryExpr(
+      const googlesql::ResolvedSubqueryExpr* node) override;
 
  private:
   // Map of column id(s) of columns referenced from the insert row (i.e. of the

--- a/backend/query/query_engine_test.cc
+++ b/backend/query/query_engine_test.cc
@@ -1900,10 +1900,6 @@ TEST_P(QueryEngineTest, InsertOnConflictDoUpdateDml) {
 }
 
 TEST_P(QueryEngineTest, InsertOnConflictDoUpdateSubqueryCanReferenceExcluded) {
-  if (GetParam() == POSTGRESQL) {
-    GTEST_SKIP() << "GoogleSQL-specific regression test";
-  }
-
   MockRowWriter writer;
   EXPECT_CALL(
       writer,

--- a/backend/query/query_engine_test.cc
+++ b/backend/query/query_engine_test.cc
@@ -1899,6 +1899,39 @@ TEST_P(QueryEngineTest, InsertOnConflictDoUpdateDml) {
   EXPECT_EQ(result.modified_row_count, 2);
 }
 
+TEST_P(QueryEngineTest, InsertOnConflictDoUpdateSubqueryCanReferenceExcluded) {
+  if (GetParam() == POSTGRESQL) {
+    GTEST_SKIP() << "GoogleSQL-specific regression test";
+  }
+
+  MockRowWriter writer;
+  EXPECT_CALL(
+      writer,
+      Write(Property(
+          &Mutation::ops,
+          UnorderedElementsAre(AllOf(
+              Field(&MutationOp::type, MutationOpType::kUpdate),
+              Field(&MutationOp::table, "test_table"),
+              Field(&MutationOp::columns,
+                    std::vector<std::string>{"int64_col", "string_col"}),
+              Field(&MutationOp::rows,
+                    UnorderedElementsAre(ValueList{Int64(1), String("ten")})))))))
+      .Times(1)
+      .WillOnce(Return(absl::OkStatus()));
+
+  GOOGLESQL_ASSERT_OK_AND_ASSIGN(
+      QueryResult result,
+      query_engine().ExecuteSql(
+          Query{"INSERT INTO test_table (int64_col, string_col) "
+                "VALUES(1, 'ten') "
+                "ON CONFLICT(int64_col) DO UPDATE SET string_col = "
+                "(SELECT excluded.string_col)"},
+          QueryContext{schema(), reader(), &writer}));
+
+  ASSERT_EQ(result.rows, nullptr);
+  EXPECT_EQ(result.modified_row_count, 1);
+}
+
 TEST_P(QueryEngineTest, InsertOnConflictDoUpdateDmlWithReturning) {
   std::string returning =
       (GetParam() == POSTGRESQL) ? "RETURNING" : "THEN RETURN WITH ACTION";

--- a/backend/query/query_engine_test.cc
+++ b/backend/query/query_engine_test.cc
@@ -1911,7 +1911,8 @@ TEST_P(QueryEngineTest, InsertOnConflictDoUpdateSubqueryCanReferenceExcluded) {
               Field(&MutationOp::columns,
                     std::vector<std::string>{"int64_col", "string_col"}),
               Field(&MutationOp::rows,
-                    UnorderedElementsAre(ValueList{Int64(1), String("ten")})))))))
+                    UnorderedElementsAre(
+                        ValueList{Int64(1), String("one-ten")})))))))
       .Times(1)
       .WillOnce(Return(absl::OkStatus()));
 
@@ -1921,7 +1922,8 @@ TEST_P(QueryEngineTest, InsertOnConflictDoUpdateSubqueryCanReferenceExcluded) {
           Query{"INSERT INTO test_table (int64_col, string_col) "
                 "VALUES(1, 'ten') "
                 "ON CONFLICT(int64_col) DO UPDATE SET string_col = "
-                "(SELECT excluded.string_col)"},
+                "(SELECT CONCAT(t.string_col, '-', excluded.string_col) "
+                "FROM test_table t WHERE t.int64_col = 1)"},
           QueryContext{schema(), reader(), &writer}));
 
   ASSERT_EQ(result.rows, nullptr);


### PR DESCRIPTION
INSERT ... ON CONFLICT DO UPDATE rewrites `excluded` column references to read from the source row struct. That rewrite was also being applied while copying `ResolvedSubqueryExpr` parameter lists, even though those lists can only contain `ResolvedColumnRef` nodes. For a `DO UPDATE` expression like `(SELECT excluded.string_col)`, the deep-copy visitor tried to consume the replacement `GET_STRUCT_FIELD` expression as a column ref and failed an internal stack invariant.

This changes subquery copying so `excluded` parameters are remapped to the source struct column, while references inside the subquery body continue to be rewritten to field reads. It also preserves the correlated bit on replacement refs and adds a regression test for the crashing query shape.

Tested:
- `bazel test //backend/query:query_engine_test --test_filter=QueryEnginePerDialectTests/QueryEngineTest.InsertOnConflictDoUpdateSubqueryCanReferenceExcluded* --jobs=1 --local_resources=memory=4096 --local_resources=cpu=1`
- `bazel test //backend/query:query_engine_test --test_filter=QueryEnginePerDialectTests/QueryEngineTest.InsertOnConflictDoUpdate* --jobs=1 --local_resources=memory=4096 --local_resources=cpu=1`