### PR TITLE
Support Bazel 9 rule migration and JavaCC

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,6 +5,9 @@ build --cxxopt=-std=c++20
 build --host_cxxopt=-std=c++20
 build --conlyopt=-std=gnu11
 
+# Keep dependencies that still use native C++ and proto rules working on Bazel 9.
+build --incompatible_autoload_externally=+cc_binary,+cc_library,+cc_test,+cc_proto_library,+java_proto_library,+proto_library
+
 # Ensure Bazel uses the correct system paths for the compiler
 build --action_env=CC
 build --action_env=CXX

--- a/backend/common/javacc_parser.bzl
+++ b/backend/common/javacc_parser.bzl
@@ -61,11 +61,12 @@ def generate_javacc_parser(name, srcs, parser_class_name, extra_deps, extra_head
         srcs = schema_merged_tree,
         outs = schema_ast_genfiles + [schema_grammar_file],
         cmd = (
-            "$(location @local_jdk//:bin/java) -cp $(location @maven//:net_java_dev_javacc_javacc) jjtree  " +
+            "$(JAVABASE)/bin/java -cp $(location @maven//:net_java_dev_javacc_javacc) jjtree  " +
             "-OUTPUT_DIRECTORY=$(@D) " +
             "-OUTPUT_FILE=" + schema_grammar_file + " $(SRCS) "
         ),
-        tools = ["@maven//:net_java_dev_javacc_javacc", "@local_jdk//:bin/jar", "@local_jdk//:bin/java"],
+        toolchains = ["@rules_java//toolchains:remotejdk_21"],
+        tools = ["@maven//:net_java_dev_javacc_javacc", "@rules_java//toolchains:remotejdk_21"],
     )
 
     # Generate the lexer and parser files from the grammar file in .jj
@@ -93,10 +94,11 @@ def generate_javacc_parser(name, srcs, parser_class_name, extra_deps, extra_head
         srcs = [schema_grammar_file],
         outs = schema_parser_genfiles,
         cmd = (
-            "$(location @local_jdk//:bin/java) -cp $(location @maven//:net_java_dev_javacc_javacc) javacc  " +
+            "$(JAVABASE)/bin/java -cp $(location @maven//:net_java_dev_javacc_javacc) javacc  " +
             "-OUTPUT_DIRECTORY=$(@D) $(SRCS) "
         ),
-        tools = ["@maven//:net_java_dev_javacc_javacc", "@local_jdk//:bin/jar", "@local_jdk//:bin/java"],
+        toolchains = ["@rules_java//toolchains:remotejdk_21"],
+        tools = ["@maven//:net_java_dev_javacc_javacc", "@rules_java//toolchains:remotejdk_21"],
     )
 
     # Finally use generated AST and Parser files to produce c++ parser.

--- a/build/bazel/farmhash.BUILD
+++ b/build/bazel/farmhash.BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 licenses(["notice"])  # Apache v2.0
 
 cc_library(

--- a/build/bazel/googleapis.BUILD
+++ b/build/bazel/googleapis.BUILD
@@ -1,4 +1,6 @@
 # Taken from https://github.com/googleapis/google-cloud-cpp/blob/5c397c5f351b91c40dd85d5c8c009596538bfe66/bazel/googleapis.BUILD
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])

--- a/build/bazel/net_zstd.BUILD
+++ b/build/bazel/net_zstd.BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(
     default_visibility = ["//visibility:public"],
     features = ["header_modules"],


### PR DESCRIPTION
Bazel 9 removes native C++ and proto rules used by several transitive
dependencies and no longer exposes the local JDK file targets referenced
by the JavaCC parser rules.

Load C++ rules explicitly in emulator-owned BUILD overlays, enable
Bazel's external-rule migration for unchanged third-party BUILD files,
and run JavaCC using the complete Java 21 runtime toolchain. The
migration flag remains supported by the project's pinned Bazel 7.6.1.
