### PR TITLE
Keep development dependencies root-only

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -35,7 +35,7 @@ bazel_dep(name = "javacc", version = "7.0.13")
 bazel_dep(name = "rules_cc", version = "0.2.14")
 bazel_dep(name = "rules_go", version = "0.60.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_java", version = "9.0.3")
-bazel_dep(name = "rules_pkg", version = "1.0.1")
+bazel_dep(name = "rules_pkg", version = "1.0.1", dev_dependency = True)
 bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "rules_proto_grpc_go", version = "5.8.0")
 bazel_dep(name = "rules_python", version = "1.8.3")
@@ -45,9 +45,9 @@ bazel_dep(name = "platforms", version = "1.0.0")
 # C Toolchain                                                                   #
 ################################################################################
 
-bazel_dep(name = "gcc_toolchain", version = "0.9.0")
+bazel_dep(name = "gcc_toolchain", version = "0.9.0", dev_dependency = True)
 
-register_toolchains("@gcc_toolchain//:all")
+register_toolchains("@gcc_toolchain//:all", dev_dependency = True)
 
 ################################################################################
 # GoogleAPIs                                                                   #
@@ -100,14 +100,18 @@ maven.install(
 
 bazel_dep(name = "gazelle", version = "0.45.0", repo_name = "bazel_gazelle")
 
-go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk = use_extension(
+    "@io_bazel_rules_go//go:extensions.bzl",
+    "go_sdk",
+    dev_dependency = True,
+)
 go_sdk.download(
     name = "go_sdk",
     version = "1.25.11",
 )
 use_repo(go_sdk, "go_sdk")
 
-register_toolchains("@go_sdk//:all")
+register_toolchains("@go_sdk//:all", dev_dependency = True)
 
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
@@ -244,14 +248,18 @@ archive_override(
 # Python Libraries                                                             #
 ################################################################################
 
-python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python = use_extension(
+    "@rules_python//python/extensions:python.bzl",
+    "python",
+    dev_dependency = True,
+)
 python.toolchain(
     is_default = True,
     python_version = "3.11",
 )
 use_repo(python, "python_3_11")
 
-register_toolchains("@python_3_11//:all")
+register_toolchains("@python_3_11//:all", dev_dependency = True)
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(


### PR DESCRIPTION
The emulator currently registers its GCC, Go, and Python development
toolchains in every module graph that depends on it, overriding SDK
choices owned by the consuming root module.

Mark the packaging rules and GCC toolchain module as development
dependencies, make the Go and Python SDK extensions development-only,
and restrict all three toolchain registrations to the root module. Keep
the JavaCC JDK, Go module dependencies, and Python package hub available
because emulator production targets still require them.
